### PR TITLE
Make `send` a generator

### DIFF
--- a/examples/1_chat_agents/chat_agent.py
+++ b/examples/1_chat_agents/chat_agent.py
@@ -16,6 +16,6 @@ if __name__ == "__main__":
     @myagent.send(route="custom_send")
     async def custom_send():
         msg = await ainput("s> ")
-        return msg
+        yield msg
 
     myagent.run(host = "127.0.0.1", port = 8888)

--- a/examples/2_question_answer_agents/answer_agent.py
+++ b/examples/2_question_answer_agents/answer_agent.py
@@ -30,7 +30,8 @@ if __name__ == "__main__":
         async with track_lock:
             for k, q in track_questions.items():
                 del track_questions[k]
-                return ANSWERS[q]
-        return "waiting"
+                yield ANSWERS[q]
+                return
+        yield "waiting"
 
     agent.run(host="127.0.0.1", port=8888)

--- a/examples/2_question_answer_agents/question_agent.py
+++ b/examples/2_question_answer_agents/question_agent.py
@@ -27,6 +27,6 @@ if __name__ == "__main__":
     @agent.send(route="")
     async def send_question():
         await asyncio.sleep(2)
-        return QUESTIONS[tracker["count"] % len(QUESTIONS)]
+        yield QUESTIONS[tracker["count"] % len(QUESTIONS)]
 
     agent.run(host="127.0.0.1", port=8888)

--- a/examples/3_buyer_seller_agents/buyer_agent.py
+++ b/examples/3_buyer_seller_agents/buyer_agent.py
@@ -125,16 +125,16 @@ if __name__ == "__main__":
 
             if decision == "interested":
                 print(f"\033[96m[{agent.name}] Interested in offer: {offer}\033[0m")
-                return {"status": "interested", "price": offer}
+                yield {"status": "interested", "price": offer}
             elif decision == "accept":
                 print(f"\033[92m[{agent.name}] Accepted offer: {offer}\033[0m")
-                return {"status": "accept", "price": offer}
+                yield {"status": "accept", "price": offer}
             elif decision == "refuse":
                 print(f"\033[91m[{agent.name}] Refused offer: {offer}\033[0m")
-                return {"status": "refuse", "price": offer}
+                yield {"status": "refuse", "price": offer}
             else:
                 print(f"\033[93m[{agent.name}] Offering price: {offer}\033[0m")
-                return {"status": "offer", "price": offer}
+                yield {"status": "offer", "price": offer}
 
         agent.loop.create_task(negotiation(agent))
 

--- a/examples/3_buyer_seller_agents/seller_agent.py
+++ b/examples/3_buyer_seller_agents/seller_agent.py
@@ -125,18 +125,18 @@ if __name__ == "__main__":
 
             if decision == "interested":
                 print(f"\033[96m[{agent.name}] Interested in offer: {offer}\033[0m")
-                return {"status": "interested", "price": offer}
+                yield {"status": "interested", "price": offer}
             elif decision == "accept":
                 print(f"\033[92m[{agent.name}] Accepted offer: {offer}\033[0m")
-                return {"status": "accept", "price": offer}
+                yield {"status": "accept", "price": offer}
             elif decision == "refuse":
                 print(f"\033[91m[{agent.name}] Refused offer: {offer}\033[0m")
-                return {"status": "refuse", "price": offer}
+                yield {"status": "refuse", "price": offer}
             elif in_talk:
                 print(f"\033[93m[{agent.name}] Offering price: {offer}\033[0m")
-                return {"status": "offer", "price": offer}
+                yield {"status": "offer", "price": offer}
             else:
-                return {"status": "waiting"}
+                yield {"status": "waiting"}
                 
         agent.loop.create_task(negotiation(agent))
 


### PR DESCRIPTION
There are a few reasons why this is preferable I think. Right now, if someone wants to send multiple messages as a result of one iteration of `send` then that is prohibitively challenging to do. Let's make `send` a generator so that this is less of a headache.

We may need to allow yielding multiple messages (in a list) but that may be confusing because if the user is just sending a literal list (as one message) then the semantics collide.